### PR TITLE
Managed_Table 서치 함수에서 은근히 치명적인 오류를 발견

### DIFF
--- a/server/src/others/managed_data_domain.py
+++ b/server/src/others/managed_data_domain.py
@@ -476,8 +476,10 @@ class ManagedTable:
                 return val.strip() in SKIP_TUPLE
 
             if isinstance(val, list):
+                # 리스트가 공백인 경우에는 진짜 아무것도 서치하지 않겠다는 의미이므로..
+                # 예외로 Skip하지 않겠습니다.
                 if len(val) == 0:
-                    return True
+                    return False
                 return str(val[0]).strip() in SKIP_TUPLE
 
             return True


### PR DESCRIPTION
Managed_Table 서치 로직에서 필터링 파라미터를 공백리스트로 반환한다면 서치를 스킵해서 전체 데이터프레임을 반환 하는 문제 해결